### PR TITLE
Fix dataset chunk decoding

### DIFF
--- a/src/utils/generateDatasets.ts
+++ b/src/utils/generateDatasets.ts
@@ -1,6 +1,6 @@
 import OpenAI from "openai";
 import { extractTextFromFileUrl } from "./files";
-import { encode } from "gpt-3-encoder"; // Import the GPT-3 encoder to handle token counting
+import { encode, decode } from "gpt-3-encoder"; // Import encoder and decoder for token handling
 const fs = require("fs");
 
 function writeJSONLToFile(jsonArray: any[], filePath: string) {
@@ -237,9 +237,9 @@ function splitTextIntoChunks(text: string, tokensPerChunk: number = 500): string
   return chunks;
 }
 
-// Simple token decoder placeholder (modify based on encoding method)
+// Decode token IDs back into their original string values
 function decodeTokens(tokens: number[]): string {
-  return tokens.join(" "); // Adjust decoding logic if necessary
+  return decode(tokens);
 }
 
 // Add a new utility function for API call retries with exponential backoff


### PR DESCRIPTION
## Summary
- correctly decode token IDs back into text when splitting chunks

## Testing
- `npm run build` *(fails: Cannot find module '@supabase/supabase-js' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_685d3c5a76f48325af488b8f44f4a1f3